### PR TITLE
Run tests under Travis CI

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -290,6 +290,7 @@ Task("Appveyor")
 
 Task("Travis")
     .IsDependentOn("Build")
+    .IsDependentOn("Test")
     .IsDependentOn("PackageZip");
 
 Task("All")

--- a/src/TestCentric/tests/Views/CommonViewTests.cs
+++ b/src/TestCentric/tests/Views/CommonViewTests.cs
@@ -30,6 +30,7 @@ namespace TestCentric.Gui.Views
 {
     [TestFixture(typeof(MainForm))]
     [TestFixture(typeof(TestTreeView))]
+	[Platform(Exclude = "Linux", Reason = "Uninitialized form causes an error in Travis-CI")]
     public class CommonViewTests<T> where T: new()
     {
         protected T View { get; private set; }

--- a/src/TestCentric/tests/Views/MainFormTests.cs
+++ b/src/TestCentric/tests/Views/MainFormTests.cs
@@ -27,6 +27,7 @@ using NUnit.UiKit.Elements;
 
 namespace TestCentric.Gui.Views
 {
+	[Platform(Exclude="Linux", Reason="Uninitialized form causes an error in Travis-CI")]
     public class MainFormTests
     {
         private IMainView _view;


### PR DESCRIPTION
Up to now, we didn't run tests in Travis at all.There were only a few fixes having to do with Newline plus a large number of tests of the Views that create the view classes without properly initializing them. This works for our tests in Windows but not Linux.