### PR TITLE
Fix build to use MsBuild under Mono 5 or greater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: csharp
 sudo: false
 mono:
   - latest
+  - 5.10.1
   - 4.6.2
 script: 
   - git fetch --unshallow

--- a/src/TestCentric/tests/Views/MainFormTests.cs
+++ b/src/TestCentric/tests/Views/MainFormTests.cs
@@ -10,7 +10,7 @@
 // the following conditions:
 // 
 // The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
+// included in all copies or substantial portions of the Software.-
 // 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF


### PR DESCRIPTION
This works around a bug whereby Cake can't find msbuild on Linux. If we want this to work on OsX, then further changes would be needed.