### PR TITLE
Use console 3.9

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#tool nuget:?package=NUnit.ConsoleRunner&version=3.7.0
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.9.0
 #tool nuget:?package=GitVersion.CommandLine
 
 using System.Text.RegularExpressions;

--- a/build.cake
+++ b/build.cake
@@ -75,14 +75,6 @@ var GUI_SOLUTION = PROJECT_DIR + "experimental-gui.sln";
 // Test Assembly
 var GUI_TESTS = BIN_DIR + "TestCentric.Gui.Tests.dll";
 
-// Package sources for nuget restore
-var PACKAGE_SOURCE = new string[]
-{
-    "https://www.nuget.org/api/v2",
-    "https://www.myget.org/F/nunit-gui-team/api/v3/index.json",
-    "https://www.myget.org/F/nunit-gui-team/api/v2"
-};
-
 //////////////////////////////////////////////////////////////////////
 // CLEAN
 //////////////////////////////////////////////////////////////////////
@@ -103,7 +95,6 @@ Task("RestorePackages")
 {
     NuGetRestore(GUI_SOLUTION, new NuGetRestoreSettings
     {
-        Source = PACKAGE_SOURCE,
         Verbosity = NuGetVerbosity.Detailed
     });
 });

--- a/experimental-gui.sln
+++ b/experimental-gui.sln
@@ -13,8 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.sh = build.sh
 		CHANGES.txt = CHANGES.txt
 		GitVersion.yml = GitVersion.yml
-		LICENSE.txt = LICENSE.txt
 		NuGet.config = NuGet.config
+		LICENSE = LICENSE
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "choco", "choco", "{1EA16CB4-2043-4297-BABC-A548900BA7E0}"

--- a/src/tests/mock-assembly/mock-assembly.csproj
+++ b/src/tests/mock-assembly/mock-assembly.csproj
@@ -12,7 +12,6 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
     <OutputType>Library</OutputType>
     <RootNamespace>NUnit.Tests</RootNamespace>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>


### PR DESCRIPTION
We run tests of the GUI using the NUnit3 Cake extension. Currently it's set up to use the 3.7 version of the console. This updates it to use 3.9.