### PR TITLE
Remove ToolTipText prop from ICommand

### DIFF
--- a/src/TestCentric/components/Elements/ICommand.cs
+++ b/src/TestCentric/components/Elements/ICommand.cs
@@ -46,8 +46,6 @@ namespace TestCentric.Gui.Elements
         /// toolStripItem is associated.
         /// </summary>
         event CommandHandler Execute;
-
-        string ToolTipText { get; set; }
     }
 
     public interface ICommand<T> : IViewElement


### PR DESCRIPTION
Part of #276 

The property was duplicated in both ICommand and IToolStripElement