### PR TITLE
Remove additional definition of ToolTipText property

### DIFF
--- a/src/TestCentric/components/Elements/ICommand.cs
+++ b/src/TestCentric/components/Elements/ICommand.cs
@@ -51,7 +51,5 @@ namespace TestCentric.Gui.Elements
     public interface ICommand<T> : IViewElement
     {
         event CommandHandler<T> Execute;
-
-        string ToolTipText { get; set; }
     }
 }


### PR DESCRIPTION
Part of #276 

Property was defined in both ICommand and ICommand<T>