### PR TITLE
Kluge to make results display on Linux

### DIFF
--- a/src/TestCentric/testcentric.gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/TestCentric/testcentric.gui/Presenters/TestPropertiesPresenter.cs
@@ -91,7 +91,11 @@ namespace TestCentric.Gui.Presenters
             }
 
             _view.TestPanel.Visible = testNode != null;
-            _view.ResultPanel.Visible = resultNode != null;
+            // HACK: results won't display on Linux otherwise
+            if (Path.DirectorySeparatorChar == '/') // Running on Linux or Unix
+                _view.ResultPanel.Visible = true;
+            else
+                _view.ResultPanel.Visible = resultNode != null;
 
             // TODO: We should actually try to set the font for bold items
             // dynamically, since the global application font may be changed.


### PR DESCRIPTION
Fixes #282 

The only way I have been able to make it work is to always display the result panel on Linux. It's a hack but I don't think there's any harm to showing the empty panel when there are no results.